### PR TITLE
fix(cli): init テンプレートの依存バージョン整合

### DIFF
--- a/.changeset/fix-init-template-versions.md
+++ b/.changeset/fix-init-template-versions.md
@@ -1,0 +1,12 @@
+---
+"@deckspec/cli": patch
+"@deckspec/dsl": patch
+"@deckspec/schema": patch
+"@deckspec/renderer": patch
+"@deckspec/theme-noir-display": patch
+---
+
+`deckspec init` で生成される `package.json` のテンプレートを修正:
+
+- `@deckspec/cli` の semver range を `^0.1.0` → `^0.2.0` に更新 (^0.1.0 では現行 0.2.x が解決できなかった)
+- `lucide-react` の semver range を `^0.469.0` → `^1.7.0` に更新し、テーマパッケージの依存と整合

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -108,9 +108,9 @@ function generatePackageJson(): string {
       private: true,
       type: "module",
       dependencies: {
-        "@deckspec/cli": "^0.1.0",
+        "@deckspec/cli": "^0.2.0",
         "@phosphor-icons/react": "^2.1.0",
-        "lucide-react": "^0.469.0",
+        "lucide-react": "^1.7.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "zod": "^3.23.0",


### PR DESCRIPTION
## Summary

`deckspec init` が生成する `package.json` のテンプレートに古い semver range が残っていたので整合させる。

- `@deckspec/cli`: `^0.1.0` → `^0.2.0`
  semver の 0.x 系は caret が minor を吸収しないため、`^0.1.0` だと現行の 0.2.x が install できない (ユーザー側 init が壊れる)
- `lucide-react`: `^0.469.0` → `^1.7.0`
  theme パッケージは既に lucide-react 1.x を使っているため整合

## Test plan

- [x] `pnpm build` 成功
- [x] `pnpm test` 成功
- [x] changeset 同梱 (fixed-group なので 5 パッケージ全て patch bump)
- [ ] CI green