### PR TITLE
chore(ci): NPM_TOKEN を撤去して Trusted Publisher (OIDC) に統一

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 permissions:
   contents: write      # changesets が Version PR・タグ作成に必要
   pull-requests: write # changesets が PR 更新に必要
-  id-token: write      # npm provenance (出所証明) に必要
+  id-token: write      # npm Trusted Publisher (OIDC) で publish するため
 
 jobs:
   release:
@@ -25,13 +25,16 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
+      # npm Trusted Publisher (OIDC) で publish する。NPM_TOKEN は意図的に
+      # 渡さない — env に NPM_TOKEN があると changesets/action が .npmrc に
+      # トークンを書き込んで OIDC ではなくトークン認証になってしまう。
       - uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
-          publish: pnpm -r publish --provenance
+          publish: pnpm -r publish --provenance --access public
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

5パッケージすべてに Trusted Publisher が設定済みになったので、release workflow から `NPM_TOKEN` を撤去。OIDC 経由でのみ publish するようにする。

## 失敗原因の確定

直近3回の release run が全て `404 Not Found - PUT @deckspec/schema` で失敗。ログを見ると:

\`\`\`
No user .npmrc file found, creating one with NPM_TOKEN used as auth token
\`\`\`

changesets/action は env に \`NPM_TOKEN\` があると \`.npmrc\` にトークンを書き込み、それで認証してしまう。一方、マサユキが 2FA を account-wide に有効化したため、その旧トークンでは publish できなくなっていた → 404。

## 修正内容

- \`env.NPM_TOKEN\` を削除
- setup-node に \`registry-url: 'https://registry.npmjs.org'\` を追加 (OIDC で \`.npmrc\` を正しく構成するため)
- \`pnpm -r publish\` に \`--access public\` を明示

## 副次効果

- リポジトリから static secret が一掃される (PR マージ後、 \`gh secret delete NPM_TOKEN\` で消せる)
- 万一漏れる secret が物理的に存在しないので、TanStack 型攻撃の影響を受けない

## Test plan

- [ ] CI green
- [ ] マージ後 \`gh workflow run release.yml --ref main\` で 0.2.1 が npm に公開できることを確認