### PR TITLE
chore(ci): publish を npm CLI に切り替えて OIDC 安定化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,11 +30,14 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
 
-      # npm Trusted Publisher (OIDC) で publish する。NPM_TOKEN は意図的に
-      # 渡さない — env に NPM_TOKEN があると changesets/action が .npmrc に
-      # トークンを書き込んで OIDC ではなくトークン認証になってしまう。
+      # OIDC を確実に使うため、publish は npm CLI に揃える (pnpm 9 の OIDC
+      # 実装は不安定で、npm 側 Trusted Publisher と組み合わせると 404 になる)。
+      # 11.5.1+ の npm に上げ、changesets/action から呼ぶ。
+      - run: npm install -g npm@latest
+
+      # npm Trusted Publisher (OIDC) で publish。NPM_TOKEN は意図的に渡さない。
       - uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
-          publish: pnpm -r publish --provenance --access public
+          publish: ./scripts/publish.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# scripts/publish.sh — workspace 内の各パッケージを npm CLI で publish する。
+#
+# changesets/action から呼ばれる。npm Trusted Publisher (OIDC) を使うため、
+# pnpm publish ではなく npm publish を直接実行する (pnpm 9.x の OIDC 実装
+# は npm Trusted Publisher と組み合わせると 404 を返すバグがあるため)。
+#
+# 同じバージョンが既に npm に公開されている場合はスキップする。
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+for pkg_json in "$ROOT"/packages/*/package.json "$ROOT"/themes/*/package.json; do
+  pkg_dir="$(dirname "$pkg_json")"
+  name="$(node -p "require('$pkg_json').name")"
+  version="$(node -p "require('$pkg_json').version")"
+
+  if [[ "$(node -p "require('$pkg_json').private || false")" == "true" ]]; then
+    echo "▸ skip $name (private)"
+    continue
+  fi
+
+  if npm view "$name@$version" version >/dev/null 2>&1; then
+    echo "▸ skip $name@$version (already published)"
+    continue
+  fi
+
+  echo "▸ publish $name@$version"
+  (cd "$pkg_dir" && npm publish --provenance --access public)
+done


### PR DESCRIPTION
## Summary

pnpm 9.x の publish OIDC 実装に既知バグがあり、npm Trusted Publisher と組み合わせると 404 (PUT) を返す。pnpm 11.0.7 で修正済みだが、pnpm メジャーアップは副作用 (postinstall 厳格化など) が大きいので、publish 段だけ npm CLI に揃える。

## 変更内容

- `scripts/publish.sh`: workspace 内のパッケージを 1つずつ `npm publish --provenance --access public` で公開。既公開バージョンは skip。
- `release.yml`: setup-node の後 `npm install -g npm@latest` で npm を 11.5.1+ に上げ、changesets/action の publish コマンドをこのスクリプトに変更。

## Test plan

- [ ] CI green
- [ ] マージで 0.2.1 が npm に公開される